### PR TITLE
Add update_adapter

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -38,3 +38,38 @@ alias p_envs='cd ~/python-virtual-environments/'
 
 # added by Anaconda3 installer
 export PATH="/home/kmayo/anaconda3/bin:$PATH"
+
+# Update displaylink adapter
+function update_adapter() {(
+    # Make errors fatal
+    set -e
+
+    # Location of DisplayLink RPM repo.
+    # Currently: https://github.com/displaylink-rpm/displaylink-rpm
+    local user="displaylink-rpm"
+    local repo="$user"
+    local api_base="https://api.github.com"
+
+    # Source /etc/os-release for distribution and version
+    . /etc/os-release
+    if [ "x$NAME" != "xFedora" ]; then
+        echo "Unknown distribution: $NAME -- only Fedora is supported."
+        return 1
+    fi
+
+    echo "Removing old displaylink package..."
+    sudo dnf remove displaylink -y || true
+
+    echo "Downloading new displaylink package..."
+    rm /tmp/displaylink.rpm /tmp/displaylink.json -rf
+    wget -O /tmp/displaylink.json "$api_base/repos/$user/$repo/releases"
+    grep -F 'browser_download_url' /tmp/displaylink.json |
+        grep -F "fedora-$VERSION_ID" |
+        grep -F "x86_64" |
+        head -n 1 |
+        grep -o 'http[s].*\.rpm' |
+        wget -i - -O /tmp/displaylink.rpm
+
+    echo "Installing new displaylink package..."
+    sudo dnf install /tmp/displaylink.rpm -y
+)}


### PR DESCRIPTION
Updates the displaylink adapter drivers from the displaylink-rpm
repository. This queries the GitHub API to find the latest Fedora
release for the current distribution.

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`